### PR TITLE
`asNull` assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ composer require std-library/type-guard
 - [`asFloat()`](#asfloat)
 - [`asString()`](#asstring)
 - [`asBool()`](#asbool)
+- [`asNull()`](#asnull)
 
 ### `as`
 
@@ -82,6 +83,14 @@ Asserts and narrows down the type of the given variable to a boolean.
 
 ```php
 $variable = type($variable)->asBool();
+```
+
+### `asNull()`
+
+Asserts and narrows down the type of the given variable to a null.
+
+```php
+$variable = type($variable)->asNull();
 ```
 
 ------

--- a/src/Type.php
+++ b/src/Type.php
@@ -98,4 +98,18 @@ final readonly class Type
         return $this->variable;
 
     }
+
+    /**
+     * Asserts and narrow down the type to null.
+     *
+     * @phpstan-assert-if-true null $this->variable
+     */
+    public function asNull(): null
+    {
+        if (! is_null($this->variable)) {
+            throw new TypeError('Variable is not a [null].');
+        }
+
+        return $this->variable;
+    }
 }

--- a/tests/AsNullTest.php
+++ b/tests/AsNullTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+test('null type', function (): void {
+    $variable = null;
+
+    $value = type($variable)->asNull();
+
+    expect($value)->toBeNull();
+});
+
+test('not null', function (): void {
+    $variable = [];
+
+    type($variable)->asNull();
+})->throws(TypeError::class, 'Variable is not a [null].');

--- a/types/AsNullTest.php
+++ b/types/AsNullTest.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+$variable = random_int(0, 1) !== 0 ? [] : null;
+assertType('null', type($variable)->asNull());


### PR DESCRIPTION
This PR introduces `asNull` assertion

```php
type(null)->asNull(); // true
type([])->asNull(); // throw TypeError exception
```